### PR TITLE
+ MiscController

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,11 @@ gem 'bootsnap', '>= 1.4.2', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'rspec-rails', git: 'https://github.com/rspec/rspec-rails', branch: '4-0-maintenance'
+  gem 'rspec-core', git: 'https://github.com/rspec/rspec-core'
+  gem 'rspec-mocks', git: 'https://github.com/rspec/rspec-mocks'
+  gem 'rspec-support', git: 'https://github.com/rspec/rspec-support'
+  gem 'rspec-expectations', git: 'https://github.com/rspec/rspec-expectations'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,46 @@
+GIT
+  remote: https://github.com/rspec/rspec-core
+  revision: b7067c5da4fde57cbbff739b168008482e61db44
+  specs:
+    rspec-core (3.10.0.pre)
+      rspec-support (= 3.10.0.pre)
+
+GIT
+  remote: https://github.com/rspec/rspec-expectations
+  revision: 99f9bcaff2a6f3d82f4e350e829eca6ab015694f
+  specs:
+    rspec-expectations (3.10.0.pre)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (= 3.10.0.pre)
+
+GIT
+  remote: https://github.com/rspec/rspec-mocks
+  revision: 5b897e8f74f3059aef43f1ed5f91719f2267a04e
+  specs:
+    rspec-mocks (3.10.0.pre)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (= 3.10.0.pre)
+
+GIT
+  remote: https://github.com/rspec/rspec-rails
+  revision: 1a1a2a17cb663474ada9741433ca64899a788656
+  branch: 4-0-maintenance
+  specs:
+    rspec-rails (4.0.0.beta3)
+      actionpack (>= 4.2)
+      activesupport (>= 4.2)
+      railties (>= 4.2)
+      rspec-core (~> 3.8)
+      rspec-expectations (~> 3.8)
+      rspec-mocks (~> 3.8)
+      rspec-support (~> 3.8)
+
+GIT
+  remote: https://github.com/rspec/rspec-support
+  revision: 673133cdd13b17077b3d88ece8d7380821f8d7dc
+  specs:
+    rspec-support (3.10.0.pre)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -289,6 +332,11 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rspec-core!
+  rspec-expectations!
+  rspec-mocks!
+  rspec-rails!
+  rspec-support!
   sass-rails (~> 5)
   selenium-webdriver
   spring

--- a/app/assets/stylesheets/misc.scss
+++ b/app/assets/stylesheets/misc.scss
@@ -1,0 +1,7 @@
+// Place all the styles related to the Misc controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+.text-center {
+  text-align: center;
+}
+

--- a/app/controllers/misc_controller.rb
+++ b/app/controllers/misc_controller.rb
@@ -1,0 +1,14 @@
+class MiscController < ApplicationController
+  def not_found
+    respond_to do |format|
+      format.html {
+        render "not_found", status: :not_found
+      }
+      format.json {
+        render json: {
+          error: "Endpoint not found"
+        }, status: :not_found
+      }
+    end
+  end
+end

--- a/app/helpers/misc_helper.rb
+++ b/app/helpers/misc_helper.rb
@@ -1,0 +1,2 @@
+module MiscHelper
+end

--- a/app/views/misc/not_found.html.erb
+++ b/app/views/misc/not_found.html.erb
@@ -1,0 +1,4 @@
+<div class="text-center">
+  <h2>404 - Not Found</h2>
+  <p>The page you were looking for could not be found.</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,7 @@ Rails.application.routes.draw do
   # Administrators who have access to /admin
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
+
+  get '/', to: 'misc#not_found'
+  get '*path', to: 'misc#not_found'
 end

--- a/spec/controllers/misc_controller_spec.rb
+++ b/spec/controllers/misc_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe MiscController, type: :controller do
+
+  context 'misc routes' do
+
+    it 'json not_found action' do
+      headers = {
+        "Accept" => "application/json"
+      }
+      request.headers.merge! headers
+
+      get :not_found
+      expect(response.code).to eq '404'
+
+      data = ActiveSupport::JSON.decode(response.body)
+      expect(data['error']).to eq "Endpoint not found"
+    end
+
+    it 'html not_found action' do
+      headers = {
+        "Accept" => "text/html"
+      }
+      request.headers.merge! headers
+
+      get :not_found
+      expect(response.code).to eq '404'
+    end
+
+  end
+
+end

--- a/spec/helpers/misc_helper_spec.rb
+++ b/spec/helpers/misc_helper_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the MiscHelper. For example:
+#
+# describe MiscHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe MiscHelper, type: :helper do
+end


### PR DESCRIPTION
Used for 404 status route matchers.

Accepts both text/html and application/json and will
return different content respectively.

application/json
    { "error": "Endpoint not found" }

text/html
    A simple HTML page showing that you're on a 404 route

Signed-off-by: Kevin Morris <kmorris@zerocost.dev>