### PR TITLE
Introduce Topic model and controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'jwt'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
+gem 'search_object'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,8 +168,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jwt (2.2.1)
     json (2.2.0)
+    jwt (2.2.1)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -252,23 +252,6 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    rspec-core (3.9.0)
-      rspec-support (~> 3.9.0)
-    rspec-expectations (3.9.0)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.0)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-rails (3.9.0)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      railties (>= 3.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.0)
     ruby_dep (1.5.0)
     rubyzip (2.0.0)
     sass (3.7.4)
@@ -290,6 +273,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    search_object (1.2.3)
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -365,6 +349,7 @@ DEPENDENCIES
   rspec-rails!
   rspec-support!
   sass-rails (~> 5)
+  search_object
   selenium-webdriver
   simplecov
   spring

--- a/app/admin/topics.rb
+++ b/app/admin/topics.rb
@@ -1,0 +1,18 @@
+ActiveAdmin.register Topic do
+  permit_params :subject, :body
+  # See permitted parameters documentation:
+  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  #
+  # Uncomment all parameters which should be permitted for assignment
+  #
+  # permit_params :subject, :body
+  #
+  # or
+  #
+  # permit_params do
+  #   permitted = [:subject, :body]
+  #   permitted << :other if params[:action] == 'create' && current_user.admin?
+  #   permitted
+  # end
+  
+end

--- a/app/assets/stylesheets/topics.scss
+++ b/app/assets/stylesheets/topics.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Topics controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,0 +1,51 @@
+class TopicsController < ApplicationController
+  include TopicsHelper
+
+  def index
+    @topics ||= Topic.all
+    render json: @topics, only: [
+      :id,
+      :subject,
+      :body
+    ]
+  end
+
+  def show
+    @topic ||= Topic.find(params[:topic_id])
+    render json: @topic, only: [
+      :id,
+      :subject,
+      :body
+    ]
+  end
+
+  def search
+    terms = []
+
+    # Split by spaces _or_ quoted substrings
+    raw = params[:terms].split(/\s(?=(?:[^"]|"[^"]*")*$)/)
+    raw.each do |t|
+      terms.push(t.gsub('"', ''))
+    end
+
+    results = []
+    terms.each do |term|
+      # For each term, find all Topics with similar
+      # subjects or bodies.
+      topics = TopicSearch.new(filters: {
+        term: term
+      })
+
+      # Combine results and uniqify them. Afterward,
+      # push our new results onto our results list
+      results += topics.results.uniq
+    end
+
+    topics = results.uniq
+    render json: topics, only: [
+      :id,
+      :subject,
+      :body
+    ]
+  end
+end

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -1,0 +1,12 @@
+module TopicsHelper
+  class TopicSearch
+    include SearchObject.module(:model)
+
+    scope { Topic.all }
+
+    option(:term) {
+      |scope, value| scope.where("topics.subject LIKE ? OR topics.body LIKE ?",
+                                 "%#{value}%", "%#{value}%")
+    }
+  end
+end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,0 +1,2 @@
+class Topic < ApplicationRecord
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,10 @@ Rails.application.routes.draw do
   get '/members', to: 'members#index'
   get '/members/:member_id', to: 'members#show'
 
+  get '/topics', to: 'topics#index'
+  get '/topics/:topic_id', to: 'topics#show'
+  post '/topics', to: 'topics#search'
+
   # Administrators who have access to /admin
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)

--- a/db/migrate/20191117170425_create_topics.rb
+++ b/db/migrate/20191117170425_create_topics.rb
@@ -1,0 +1,13 @@
+class CreateTopics < ActiveRecord::Migration[6.0]
+  def change
+    create_table :topics do |t|
+      t.text :subject, null: false
+      t.text :body, null: false
+
+      t.timestamps
+    end
+
+    add_index :topics, :subject
+    add_index :topics, :body
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_07_164548) do
+ActiveRecord::Schema.define(version: 2019_11_17_170425) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"
@@ -66,6 +66,15 @@ ActiveRecord::Schema.define(version: 2019_11_07_164548) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "title"
+  end
+
+  create_table "topics", force: :cascade do |t|
+    t.text "subject", null: false
+    t.text "body", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["body"], name: "index_topics_on_body"
+    t.index ["subject"], name: "index_topics_on_subject"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/controllers/topics_controller_spec.rb
+++ b/spec/controllers/topics_controller_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe TopicsController, type: :controller do
+
+  context 'topic routes' do
+
+    before do
+      @topic = Topic.create!({
+        subject: "Test",
+        body: "Topic"
+      })
+    end
+
+    it 'index lists all topics' do
+      get :index
+      expect(response.code).to eq '200'
+
+      data = ActiveSupport::JSON.decode(response.body)
+      expect(data.length).to eq 1
+
+      topic = data[0]
+      expect(topic['id']).to eq @topic.id
+      expect(topic['subject']).to eq @topic.subject
+      expect(topic['body']).to eq @topic.body
+    end
+
+    it 'shows a single topic' do
+      get :show, params: {
+        topic_id: @topic.id
+      }
+      expect(response.code).to eq '200'
+
+      topic = ActiveSupport::JSON.decode(response.body)
+      expect(topic['id']).to eq @topic.id
+      expect(topic['subject']).to eq @topic.subject
+      expect(topic['body']).to eq @topic.body
+    end
+
+    it 'matching search terms returns our record' do
+      get :search, params: {
+        terms: "Test"
+      }
+      expect(response.code).to eq '200'
+
+      data = ActiveSupport::JSON.decode(response.body)
+      expect(data.length).to eq 1
+
+      topic = data[0]
+      expect(topic['id']).to eq @topic.id
+      expect(topic['subject']).to eq @topic.subject
+      expect(topic['body']).to eq @topic.body
+    end
+
+    it 'matching body search terms returns our record' do
+      get :search, params: {
+        terms: "Topic"
+      }
+      expect(response.code).to eq '200'
+
+      data = ActiveSupport::JSON.decode(response.body)
+      expect(data.length).to eq 1
+
+      topic = data[0]
+      expect(topic['id']).to eq @topic.id
+      expect(topic['subject']).to eq @topic.subject
+      expect(topic['body']).to eq @topic.body
+    end
+
+    it 'unmatched search terms returns empty list' do
+      get :search, params: {
+        terms: "Blahblah"
+      }
+      expect(response.code).to eq '200'
+
+      data = ActiveSupport::JSON.decode(response.body)
+      expect(data.length).to eq 0
+    end
+
+  end
+
+end

--- a/spec/helpers/topics_helper_spec.rb
+++ b/spec/helpers/topics_helper_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the TopicsHelper. For example:
+#
+# describe TopicsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe TopicsHelper, type: :helper do
+  context 'Topic search' do
+
+    it 'search returns a single topic' do
+      @topic = Topic.create!({
+        subject: "Test",
+        body: "My little topic"
+      })
+
+      topics = TopicsHelper::TopicSearch.new(term: "Test")
+      expect(topics.count).to eq 1
+    end
+
+  end
+end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Topic, type: :model do
+  context 'manage Topic objects' do
+
+    it 'cannot create null subject objects' do
+      expect {
+        Topic.create!({
+          body: "Blah"
+        })
+      }.to raise_error ActiveRecord::NotNullViolation
+    end
+
+    it 'cannot create null body objects' do
+      expect {
+        Topic.create!({
+          subject: "Blah"
+        })
+      }.to raise_error ActiveRecord::NotNullViolation
+    end
+
+    it 'can create objects' do
+      @topic = Topic.create!({
+        subject: "Subject",
+        body: "Body"
+      })
+
+      expect(@topic.id).not_to eq nil
+      expect(@topic.subject).to eq "Subject"
+      expect(@topic.body).to eq "Body"
+    end
+
+  end
+end


### PR DESCRIPTION
Model Topic
    id: Numeric ID of the Topic's object
    subject: Text of the topic's title
    body: Text of the content of a topic

New routes (json):
    GET /topics
    GET /topics/:topic_id
        Requires param topic_id
    POST /topics
        Requires param terms, a string of search terms
        Terms separated by spaces are treated as OR terms,
        while terms inside of a quoted substring are treated
        as one large term.

Also introduce TopicsHelper::TopicSearch, a class that
aids in searching Topic objects by terms. Deep down,
TopicSearch uses a WHERE LIKE stanza to determine whether
a term exists in our object collection.

Additionally, add 'search_object' gem to Gemfile

Signed-off-by: Kevin Morris <kmorris@zerocost.dev>